### PR TITLE
Update iOS signing configuration and build command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,7 +121,8 @@ jobs:
           echo $INFO_PLIST | base64 --decode > ./ios/Runner/GoogleService-Info.plist
           echo $FIREBASE_OPTIONS | base64 --decode > ./lib/firebase_options.dart
       - name: Build iOS app
-        run: flutter build ipa --release --export-options-plist=./ios/ExportOptions.plist
+#        run: flutter build ipa --release --export-options-plist=./ios/ExportOptions.plist
+        run: flutter build ipa --release
       - name: Make build available as artifact
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,8 +121,7 @@ jobs:
           echo $INFO_PLIST | base64 --decode > ./ios/Runner/GoogleService-Info.plist
           echo $FIREBASE_OPTIONS | base64 --decode > ./lib/firebase_options.dart
       - name: Build iOS app
-#        run: flutter build ipa --release --export-options-plist=./ios/ExportOptions.plist
-        run: flutter build ipa --release
+        run: flutter build ipa --release --export-options-plist=./ios/ExportOptions.plist
       - name: Make build available as artifact
         uses: actions/upload-artifact@v6
         with:

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -12,7 +12,7 @@
         <string>Github runner provisioning profile</string>
     </dict>
     <key>signingCertificate</key>
-    <string>Apple Distribution</string>
+    <string>Apple Distribution: Francesco Battaglini (9575X675NW)</string>
     <key>signingStyle</key>
     <string>manual</string>
     <key>stripSwiftSymbols</key>

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -9,7 +9,7 @@
     <key>provisioningProfiles</key>
     <dict>
         <key>net.battaglilni.fantaF1</key>
-        <string>Github runner provisioning profile</string>
+        <string>Github runner distribution provisioning profile</string>
     </dict>
     <key>signingCertificate</key>
     <string>Apple Distribution: Francesco Battaglini (9575X675NW)</string>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -359,9 +359,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -376,9 +380,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -494,6 +502,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = "";
@@ -510,7 +519,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.battaglilni.fantaF1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Github runner provisioning profile";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Github runner distribution provisioning profile";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -690,6 +699,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = "";
@@ -706,7 +716,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.battaglilni.fantaF1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Github runner provisioning profile";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Github runner distribution provisioning profile";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
This change updates the iOS build settings for distribution and simplifies the Flutter build command in the CI workflow.

Key changes include:
*   **iOS Signing**:
    *   Updated `CODE_SIGN_IDENTITY` for `iphoneos` to "iPhone Distribution".
    *   Updated the `PROVISIONING_PROFILE_SPECIFIER` to "Github runner distribution provisioning profile" for both Debug and Release configurations.
*   **Xcode Project**: Added empty `inputPaths` and `outputPaths` to the "Embed Pods Frameworks" and "Copy Pods Resources" build phases.
*   **CI Workflow**: Simplified the iOS build step in `build.yaml` by removing the explicit `--export-options-plist` flag.

Closes #9 