### PR TITLE
feat: add race weekend recap card to race results view

### DIFF
--- a/lib/component/race_recap_card.dart
+++ b/lib/component/race_recap_card.dart
@@ -1,0 +1,78 @@
+import 'package:fanta_f1/component/section_header.dart';
+import 'package:fanta_f1/dto/race_recap/race_recap.dart';
+import 'package:fanta_f1/provider/race_recap_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class RaceRecapCard extends ConsumerWidget {
+  final String raceId;
+  const RaceRecapCard({super.key, required this.raceId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recapAsync = ref.watch(raceRecapProviderProvider(raceId));
+
+    return recapAsync.when(
+      data: (recap) {
+        if (recap == null) {
+          return const SizedBox.shrink();
+        }
+
+        return _buildRecapCard(context, recap);
+      },
+      loading: () => const SizedBox.shrink(),
+      error: (error, stack) => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildRecapCard(BuildContext context, RaceRecap recap) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(height: 16),
+        sectionHeader('Race weekend recap'),
+        SizedBox(height: 8.0),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16.0),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12.0,
+                vertical: 8.0,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 8),
+                  MarkdownBody(
+                    data: recap.recapParagraphs.join('\n\n'),
+                    styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context))
+                        .copyWith(
+                          p: Theme.of(context).textTheme.bodyMedium,
+                          blockquoteDecoration: BoxDecoration(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          blockquote: TextStyle(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurfaceVariant,
+                            fontStyle: FontStyle.italic,
+                          ),
+                          strong: Theme.of(context).textTheme.bodyMedium!
+                              .copyWith(fontWeight: FontWeight.bold),
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/dto/race_recap/race_recap.dart
+++ b/lib/dto/race_recap/race_recap.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'race_recap.freezed.dart';
+part 'race_recap.g.dart';
+
+@freezed
+@JsonSerializable()
+class RaceRecap with _$RaceRecap {
+  @override
+  final String raceId;
+  @override
+  final String raceName;
+  @override
+  final List<String> recapParagraphs;
+
+  const RaceRecap({
+    required this.raceId,
+    required this.raceName,
+    required this.recapParagraphs,
+  });
+
+  factory RaceRecap.fromJson(Map<String, dynamic> json) =>
+      _$RaceRecapFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RaceRecapToJson(this);
+}

--- a/lib/dto/race_recap/race_recap.freezed.dart
+++ b/lib/dto/race_recap/race_recap.freezed.dart
@@ -1,0 +1,202 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'race_recap.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RaceRecap {
+
+ String get raceId; String get raceName; List<String> get recapParagraphs;
+/// Create a copy of RaceRecap
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RaceRecapCopyWith<RaceRecap> get copyWith => _$RaceRecapCopyWithImpl<RaceRecap>(this as RaceRecap, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RaceRecap&&(identical(other.raceId, raceId) || other.raceId == raceId)&&(identical(other.raceName, raceName) || other.raceName == raceName)&&const DeepCollectionEquality().equals(other.recapParagraphs, recapParagraphs));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,raceId,raceName,const DeepCollectionEquality().hash(recapParagraphs));
+
+@override
+String toString() {
+  return 'RaceRecap(raceId: $raceId, raceName: $raceName, recapParagraphs: $recapParagraphs)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RaceRecapCopyWith<$Res>  {
+  factory $RaceRecapCopyWith(RaceRecap value, $Res Function(RaceRecap) _then) = _$RaceRecapCopyWithImpl;
+@useResult
+$Res call({
+ String raceId, String raceName, List<String> recapParagraphs
+});
+
+
+
+
+}
+/// @nodoc
+class _$RaceRecapCopyWithImpl<$Res>
+    implements $RaceRecapCopyWith<$Res> {
+  _$RaceRecapCopyWithImpl(this._self, this._then);
+
+  final RaceRecap _self;
+  final $Res Function(RaceRecap) _then;
+
+/// Create a copy of RaceRecap
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? raceId = null,Object? raceName = null,Object? recapParagraphs = null,}) {
+  return _then(RaceRecap(
+raceId: null == raceId ? _self.raceId : raceId // ignore: cast_nullable_to_non_nullable
+as String,raceName: null == raceName ? _self.raceName : raceName // ignore: cast_nullable_to_non_nullable
+as String,recapParagraphs: null == recapParagraphs ? _self.recapParagraphs : recapParagraphs // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RaceRecap].
+extension RaceRecapPatterns on RaceRecap {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+// dart format on

--- a/lib/dto/race_recap/race_recap.g.dart
+++ b/lib/dto/race_recap/race_recap.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'race_recap.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RaceRecap _$RaceRecapFromJson(Map<String, dynamic> json) => RaceRecap(
+  raceId: json['raceId'] as String,
+  raceName: json['raceName'] as String,
+  recapParagraphs: (json['recapParagraphs'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+);
+
+const _$RaceRecapFieldMap = <String, String>{
+  'raceId': 'raceId',
+  'raceName': 'raceName',
+  'recapParagraphs': 'recapParagraphs',
+};
+
+// ignore: unused_element
+abstract class _$RaceRecapPerFieldToJson {
+  // ignore: unused_element
+  static Object? raceId(String instance) => instance;
+  // ignore: unused_element
+  static Object? raceName(String instance) => instance;
+  // ignore: unused_element
+  static Object? recapParagraphs(List<String> instance) => instance;
+}
+
+Map<String, dynamic> _$RaceRecapToJson(RaceRecap instance) => <String, dynamic>{
+  'raceId': instance.raceId,
+  'raceName': instance.raceName,
+  'recapParagraphs': instance.recapParagraphs,
+};

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:fanta_f1/repository/driver_repository.dart';
 import 'package:fanta_f1/repository/driver_summary_repository.dart';
 import 'package:fanta_f1/repository/lineup_repository.dart';
 import 'package:fanta_f1/repository/lobby_repository.dart';
+import 'package:fanta_f1/repository/race_recap_repository.dart';
 import 'package:fanta_f1/repository/race_weekend_repository.dart';
 import 'package:fanta_f1/repository/team_repository.dart';
 import 'package:fanta_f1/repository/user_repository.dart';
@@ -65,6 +66,7 @@ Future<void> _registerInstances() async {
   getIt.registerSingleton(DriverRepository());
   getIt.registerSingleton(DriverCostRepository());
   getIt.registerSingleton(DriverSummaryRepository());
+  getIt.registerSingleton(RaceRecapRepository());
   getIt.registerSingleton(packageInfo);
   getIt.registerSingleton(sharedPreferences);
 }

--- a/lib/provider/race_recap_provider.dart
+++ b/lib/provider/race_recap_provider.dart
@@ -1,0 +1,18 @@
+import 'package:fanta_f1/dto/race_recap/race_recap.dart';
+import 'package:fanta_f1/repository/race_recap_repository.dart';
+import 'package:get_it/get_it.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'race_recap_provider.g.dart';
+
+@riverpod
+class RaceRecapProvider extends _$RaceRecapProvider {
+  final _getIt = GetIt.instance;
+  late RaceRecapRepository _raceRecapRepository;
+
+  @override
+  FutureOr<RaceRecap?> build(String raceId) async {
+    _raceRecapRepository = _getIt();
+    return await _raceRecapRepository.getRaceRecap(raceId);
+  }
+}

--- a/lib/provider/race_recap_provider.g.dart
+++ b/lib/provider/race_recap_provider.g.dart
@@ -1,0 +1,99 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'race_recap_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(RaceRecapProvider)
+final raceRecapProviderProvider = RaceRecapProviderFamily._();
+
+final class RaceRecapProviderProvider
+    extends $AsyncNotifierProvider<RaceRecapProvider, RaceRecap?> {
+  RaceRecapProviderProvider._({
+    required RaceRecapProviderFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'raceRecapProviderProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$raceRecapProviderHash();
+
+  @override
+  String toString() {
+    return r'raceRecapProviderProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  RaceRecapProvider create() => RaceRecapProvider();
+
+  @override
+  bool operator ==(Object other) {
+    return other is RaceRecapProviderProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$raceRecapProviderHash() => r'ab7b6be7e6d191d17a45509c7c09c8495b9f1999';
+
+final class RaceRecapProviderFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          RaceRecapProvider,
+          AsyncValue<RaceRecap?>,
+          RaceRecap?,
+          FutureOr<RaceRecap?>,
+          String
+        > {
+  RaceRecapProviderFamily._()
+    : super(
+        retry: null,
+        name: r'raceRecapProviderProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  RaceRecapProviderProvider call(String raceId) =>
+      RaceRecapProviderProvider._(argument: raceId, from: this);
+
+  @override
+  String toString() => r'raceRecapProviderProvider';
+}
+
+abstract class _$RaceRecapProvider extends $AsyncNotifier<RaceRecap?> {
+  late final _$args = ref.$arg as String;
+  String get raceId => _$args;
+
+  FutureOr<RaceRecap?> build(String raceId);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<RaceRecap?>, RaceRecap?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<RaceRecap?>, RaceRecap?>,
+              AsyncValue<RaceRecap?>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, () => build(_$args));
+  }
+}

--- a/lib/repository/race_recap_repository.dart
+++ b/lib/repository/race_recap_repository.dart
@@ -1,0 +1,22 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fanta_f1/dto/race_recap/race_recap.dart';
+import 'package:get_it/get_it.dart';
+
+class RaceRecapRepository {
+  final _getIt = GetIt.instance;
+  late final FirebaseFirestore _firestore;
+  late final CollectionReference _raceRecapCollection;
+
+  RaceRecapRepository() {
+    _firestore = _getIt();
+    _raceRecapCollection = _firestore.collection('race_weekend_recaps');
+  }
+
+  Future<RaceRecap?> getRaceRecap(String raceId) async {
+    final snapshot = await _raceRecapCollection.doc(raceId).get();
+    if (!snapshot.exists) {
+      return null;
+    }
+    return RaceRecap.fromJson(snapshot.data() as Map<String, dynamic>);
+  }
+}

--- a/lib/views/race_results_view.dart
+++ b/lib/views/race_results_view.dart
@@ -1,4 +1,5 @@
 import 'package:fanta_f1/component/error_card.dart';
+import 'package:fanta_f1/component/race_recap_card.dart';
 import 'package:fanta_f1/component/scores_list.dart';
 import 'package:fanta_f1/component/section_header.dart';
 import 'package:fanta_f1/component/spinner_centered.dart';
@@ -81,6 +82,7 @@ class _RaceResultsViewState extends ConsumerState<RaceResultsView> {
                   driver.acronym: driver,
               },
             ),
+            RaceRecapCard(raceId: widget.raceId),
           ],
         ),
       ),

--- a/test/component/race_recap_card_test.dart
+++ b/test/component/race_recap_card_test.dart
@@ -1,0 +1,267 @@
+import 'dart:async';
+
+import 'package:fanta_f1/component/race_recap_card.dart';
+import 'package:fanta_f1/dto/race_recap/race_recap.dart';
+import 'package:fanta_f1/provider/race_recap_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeRaceRecapProvider extends RaceRecapProvider {
+  final RaceRecap? recap;
+  final bool shouldThrow;
+
+  FakeRaceRecapProvider({this.recap, this.shouldThrow = false});
+
+  @override
+  FutureOr<RaceRecap?> build(String raceId) async {
+    if (shouldThrow) {
+      throw Exception('Failed to load recap');
+    }
+    return recap;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const testRecap = RaceRecap(
+    raceId: 'monaco-2025',
+    raceName: 'Monaco Grand Prix',
+    recapParagraphs: [
+      'A thrilling race in Monaco.',
+      'Verstappen took the lead early in the race.',
+    ],
+  );
+
+  Widget makeTestableWidget({
+    required String raceId,
+    RaceRecap? recap,
+    bool shouldThrow = false,
+  }) {
+    return ProviderScope(
+      overrides: [
+        raceRecapProviderProvider(raceId).overrideWith(
+          () => FakeRaceRecapProvider(recap: recap, shouldThrow: shouldThrow),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(body: RaceRecapCard(raceId: raceId)),
+      ),
+    );
+  }
+
+  group('RaceRecapCard', () {
+    testWidgets('renders recap card when data is available', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(makeTestableWidget(
+        raceId: 'monaco-2025',
+        recap: testRecap,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Race weekend recap'),
+        findsOneWidget,
+        reason: 'Section header should be displayed',
+      );
+      expect(
+        find.byType(MarkdownBody),
+        findsOneWidget,
+        reason: 'MarkdownBody should be present',
+      );
+      expect(
+        find.textContaining('thrilling'),
+        findsOneWidget,
+        reason: 'Markdown content should be rendered',
+      );
+      expect(
+        find.textContaining('Verstappen'),
+        findsOneWidget,
+        reason: 'Second paragraph should be rendered',
+      );
+      expect(
+        find.byType(Card),
+        findsOneWidget,
+        reason: 'Card should wrap the recap content',
+      );
+    });
+
+    testWidgets('renders markdown with multiple paragraphs', (
+      WidgetTester tester,
+    ) async {
+      const recapWithMultipleParagraphs = RaceRecap(
+        raceId: 'spa-2025',
+        raceName: 'Belgian Grand Prix',
+        recapParagraphs: [
+          'First paragraph about the race.',
+          'Second paragraph describing overtakes.',
+          'Third paragraph about the podium.',
+        ],
+      );
+
+      await tester.pumpWidget(makeTestableWidget(
+        raceId: 'spa-2025',
+        recap: recapWithMultipleParagraphs,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(MarkdownBody),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('First paragraph'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('overtakes'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('podium'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders markdown with bold text', (WidgetTester tester) async {
+      const recapWithMarkdown = RaceRecap(
+        raceId: 'monaco-2025',
+        raceName: 'Monaco Grand Prix',
+        recapParagraphs: ['**Verstappen** dominated the **qualifying**.'],
+      );
+
+      await tester.pumpWidget(makeTestableWidget(
+        raceId: 'monaco-2025',
+        recap: recapWithMarkdown,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(MarkdownBody),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('dominated'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders markdown with blockquotes', (
+      WidgetTester tester,
+    ) async {
+      const recapWithBlockquote = RaceRecap(
+        raceId: 'monaco-2025',
+        raceName: 'Monaco Grand Prix',
+        recapParagraphs: ['> A historic moment in Monaco.'],
+      );
+
+      await tester.pumpWidget(makeTestableWidget(
+        raceId: 'monaco-2025',
+        recap: recapWithBlockquote,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(MarkdownBody),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('historic'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders empty when recap is null', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(makeTestableWidget(
+        raceId: 'monaco-2025',
+        recap: null,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Race weekend recap'),
+        findsNothing,
+      );
+      expect(
+        find.byType(MarkdownBody),
+        findsNothing,
+      );
+      expect(
+        find.byType(Card),
+        findsNothing,
+      );
+    });
+
+    testWidgets('renders empty when provider throws error', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(makeTestableWidget(
+        raceId: 'monaco-2025',
+        shouldThrow: true,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Race weekend recap'),
+        findsNothing,
+      );
+      expect(
+        find.byType(MarkdownBody),
+        findsNothing,
+      );
+    });
+
+    testWidgets('renders empty while loading', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(
+        raceId: 'monaco-2025',
+        recap: testRecap,
+      ));
+
+      expect(
+        find.text('Race weekend recap'),
+        findsNothing,
+      );
+      expect(
+        find.byType(MarkdownBody),
+        findsNothing,
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Race weekend recap'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders empty with single paragraph', (
+      WidgetTester tester,
+    ) async {
+      const singleParagraphRecap = RaceRecap(
+        raceId: 'monaco-2025',
+        raceName: 'Monaco Grand Prix',
+        recapParagraphs: ['A single paragraph recap.'],
+      );
+
+      await tester.pumpWidget(makeTestableWidget(
+        raceId: 'monaco-2025',
+        recap: singleParagraphRecap,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(MarkdownBody),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('single paragraph'),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/repository/race_recap_repository_test.dart
+++ b/test/repository/race_recap_repository_test.dart
@@ -1,0 +1,111 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fanta_f1/dto/race_recap/race_recap.dart';
+import 'package:fanta_f1/repository/race_recap_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mock/firestore.mocks.dart';
+
+void main() {
+  late RaceRecapRepository repository;
+  late MockFirebaseFirestore mockFirestore;
+  late MockCollectionReference mockCollection;
+  late MockDocumentReference mockDocumentReference;
+  late MockDocumentSnapshot mockDocumentSnapshot;
+
+  setUp(() {
+    mockFirestore = MockFirebaseFirestore();
+    mockCollection = MockCollectionReference();
+    mockDocumentReference = MockDocumentReference();
+    mockDocumentSnapshot = MockDocumentSnapshot();
+
+    final getIt = GetIt.instance;
+    if (getIt.isRegistered<FirebaseFirestore>()) {
+      getIt.unregister<FirebaseFirestore>();
+    }
+    getIt.registerSingleton<FirebaseFirestore>(mockFirestore);
+
+    when(mockFirestore.collection('race_weekend_recaps')).thenReturn(
+      mockCollection,
+    );
+    when(mockCollection.doc('monaco-2025')).thenReturn(mockDocumentReference);
+
+    repository = RaceRecapRepository();
+  });
+
+  tearDown(() {
+    GetIt.instance.reset();
+  });
+
+  group('RaceRecapRepository', () {
+    test('getRaceRecap returns RaceRecap when document exists', () async {
+      final recapData = {
+        'raceId': 'monaco-2025',
+        'raceName': 'Monaco Grand Prix',
+        'recapParagraphs': [
+          'A thrilling race in Monaco.',
+          'Verstappen took the lead early.',
+        ],
+      };
+
+      when(mockDocumentReference.get()).thenAnswer(
+        (_) async => mockDocumentSnapshot,
+      );
+      when(mockDocumentSnapshot.exists).thenReturn(true);
+      when(mockDocumentSnapshot.data()).thenReturn(recapData);
+
+      final result = await repository.getRaceRecap('monaco-2025');
+
+      expect(result, isA<RaceRecap>());
+      expect(result!.raceId, 'monaco-2025');
+      expect(result.raceName, 'Monaco Grand Prix');
+      expect(result.recapParagraphs.length, 2);
+      expect(result.recapParagraphs[0], 'A thrilling race in Monaco.');
+      expect(result.recapParagraphs[1], 'Verstappen took the lead early.');
+
+      verify(mockFirestore.collection('race_weekend_recaps')).called(1);
+      verify(mockCollection.doc('monaco-2025')).called(1);
+      verify(mockDocumentReference.get()).called(1);
+    });
+
+    test('getRaceRecap returns null when document does not exist', () async {
+      when(mockDocumentReference.get()).thenAnswer(
+        (_) async => mockDocumentSnapshot,
+      );
+      when(mockDocumentSnapshot.exists).thenReturn(false);
+
+      final result = await repository.getRaceRecap('monaco-2025');
+
+      expect(result, isNull);
+
+      verify(mockDocumentReference.get()).called(1);
+    });
+
+    test('getRaceRecap parses multiple recap paragraphs', () async {
+      final recapData = {
+        'raceId': 'spa-2025',
+        'raceName': 'Belgian Grand Prix',
+        'recapParagraphs': [
+          'Paragraph one content.',
+          'Paragraph two content.',
+          'Paragraph three content.',
+        ],
+      };
+
+      when(mockCollection.doc('spa-2025')).thenReturn(mockDocumentReference);
+      when(mockDocumentReference.get()).thenAnswer(
+        (_) async => mockDocumentSnapshot,
+      );
+      when(mockDocumentSnapshot.exists).thenReturn(true);
+      when(mockDocumentSnapshot.data()).thenReturn(recapData);
+
+      final result = await repository.getRaceRecap('spa-2025');
+
+      expect(result, isA<RaceRecap>());
+      expect(result!.raceId, 'spa-2025');
+      expect(result.raceName, 'Belgian Grand Prix');
+      expect(result.recapParagraphs.length, 3);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add AI-generated race weekend recap feature that displays markdown-formatted recap paragraphs from the `race_weekend_recaps` Firestore collection
- Recap card automatically appears in the race results view when a recap is available for the race
- When no recap exists, the card is hidden (no visual change)

## Changes

### New files
- **`lib/dto/race_recap/race_recap.dart`** - Freezed DTO with `raceId`, `raceName`, and `recapParagraphs` fields
- **`lib/repository/race_recap_repository.dart`** - Repository for fetching recaps by raceId from Firestore
- **`lib/provider/race_recap_provider.dart`** - Riverpod family provider for lazy-loaded recap data
- **`lib/component/race_recap_card.dart`** - UI card component using `flutter_markdown` to render recap paragraphs
- **`test/repository/race_recap_repository_test.dart`** - 3 unit tests
- **`test/component/race_recap_card_test.dart`** - 8 widget tests

### Modified files
- **`lib/main.dart`** - Registered `RaceRecapRepository` singleton
- **`lib/views/race_results_view.dart`** - Added `RaceRecapCard` between race info and scores sections

## Testing

- All new unit and widget tests pass (11 tests total)
- `flutter analyze` - no new issues
- `flutter pub run build_runner build --delete-conflicting-outputs` - ran successfully